### PR TITLE
Added ability to dynamically change font size whilst tracking current…

### DIFF
--- a/lib/Gfx/TUM_Draw.c
+++ b/lib/Gfx/TUM_Draw.c
@@ -28,11 +28,11 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL2_gfxPrimitives.h>
 #include <SDL2/SDL_image.h>
-#include <SDL2/SDL_ttf.h>
 
 #include <pthread.h>
 
 #include "TUM_Draw.h"
+#include "TUM_Font.h"
 #include "TUM_Utils.h"
 
 #define ONE_BYTE 8
@@ -139,6 +139,7 @@ typedef struct text_data {
 	signed short x;
 	signed short y;
 	unsigned int colour;
+	TTF_Font *font;
 } text_data_t;
 
 typedef struct arrow_data {
@@ -181,11 +182,10 @@ const int screen_width = SCREEN_WIDTH;
 SDL_Window *window = NULL;
 SDL_Renderer *renderer = NULL;
 SDL_GLContext context = NULL;
-TTF_Font *font = NULL;
 
 char *error_message = NULL;
 
-uint32_t SwapBytes(unsigned int x)
+static uint32_t SwapBytes(unsigned int x)
 {
 	return ((x & FIRST_BYTE) << THREE_BYTES) +
 	       ((x & SECOND_BYTE) << ONE_BYTE) +
@@ -206,9 +206,6 @@ void setErrorMessage(char *msg)
 	strcpy(error_message, msg);
 }
 
-#define PRINT_TTF_ERROR(msg, ...)                                              \
-	PRINT_ERROR("[TTF Error] %s\n" #msg, (char *)TTF_GetError(),           \
-		    ##__VA_ARGS__)
 #define PRINT_SDL_ERROR(msg, ...)                                              \
 	PRINT_ERROR("[SDL Error] %s\n" #msg, (char *)SDL_GetError(),           \
 		    ##__VA_ARGS__)
@@ -433,11 +430,12 @@ static int vDrawClippedImage(SDL_Texture *tex, SDL_Renderer *ren,
 }
 
 static int vDrawText(char *string, signed short x, signed short y,
-		     unsigned int colour)
+		     unsigned int colour, TTF_Font *font)
 {
 	SDL_Color color = { RED_PORTION(colour), GREEN_PORTION(colour),
 			    BLUE_PORTION(colour), ZERO_ALPHA };
 	SDL_Surface *surface = TTF_RenderText_Solid(font, string, color);
+	tumFontPutFont(font);
 	SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, surface);
 	SDL_Rect dst = { 0 };
 	SDL_QueryTexture(texture, NULL, NULL, &dst.w, &dst.h);
@@ -453,7 +451,9 @@ static int vDrawText(char *string, signed short x, signed short y,
 static int vGetTextSize(char *string, int *width, int *height)
 {
 	SDL_Color color = { 0 };
+	TTF_Font *font = tumFontGetCurFont();
 	SDL_Surface *surface = TTF_RenderText_Solid(font, string, color);
+	tumFontPutFont(font);
 	if (surface == NULL)
 		goto err_surface;
 
@@ -542,7 +542,8 @@ static int vHandleDrawJob(draw_job_t *job)
 		break;
 	case DRAW_TEXT:
 		ret = vDrawText(job->data->text.str, job->data->text.x,
-				job->data->text.y, job->data->text.colour);
+				job->data->text.y, job->data->text.colour,
+				job->data->text.font);
 		free(job->data->text.str);
 		break;
 	case DRAW_RECT:
@@ -703,22 +704,13 @@ int vInitDrawing(char *path) // Should be called from the Thread running main()
 		goto err_sdl;
 	}
 	if (TTF_Init()) {
-		PRINT_TTF_ERROR("TTF_Init failed");
+		PRINT_ERROR("TTF_Init failed");
 		goto err_ttf;
 	}
 
-	char *buffer = prepend_path(path, FONT_LOCATION);
-	if (buffer == NULL) {
-		PRINT_ERROR("Prepending font path failed");
-		goto err_font_loc;
-	}
-
-	font = TTF_OpenFont(buffer, DEFAULT_FONT_SIZE);
-	free(buffer);
-
-	if (font == NULL) {
-		PRINT_TTF_ERROR("Opening font @ '%s' failed", FONT_LOCATION);
-		goto err_open_font;
+	if (tumFontInit(path)) {
+		PRINT_ERROR("TUM Font init failed");
+		goto err_tum_font;
 	}
 
 	window = SDL_CreateWindow(WINDOW_TITLE, SDL_WINDOWPOS_CENTERED,
@@ -757,9 +749,8 @@ err_make_current:
 err_create_context:
 	SDL_DestroyWindow(window);
 err_window:
-	TTF_CloseFont(font);
-err_open_font:
-err_font_loc:
+	tumFontExit();
+err_tum_font:
 	TTF_Quit();
 err_ttf:
 	SDL_Quit();
@@ -795,7 +786,6 @@ err_renderer:
 	SDL_DestroyWindow(window);
 err_make_current:
 	SDL_GL_DeleteContext(context);
-	TTF_CloseFont(font);
 	TTF_Quit();
 	SDL_Quit();
 	return -1;
@@ -833,6 +823,7 @@ int tumDrawText(char *str, signed short x, signed short y, unsigned int colour)
 	}
 
 	strcpy(job->data->text.str, str);
+	job->data->text.font = tumFontGetCurFont();
 	job->data->text.x = x;
 	job->data->text.y = y;
 	job->data->text.colour = colour;

--- a/lib/Gfx/TUM_Font.c
+++ b/lib/Gfx/TUM_Font.c
@@ -1,0 +1,339 @@
+
+/**
+ * @file TUM_Font.c
+ * @author Alex Hoffman
+ * @date 30 April 2020
+ * @brief Manages fonts used in TUM Draw
+ *
+ * @verbatim
+ ----------------------------------------------------------------------
+ Copyright (C) Alexander Hoffman, 2020
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ----------------------------------------------------------------------
+ @endverbatim
+ */
+
+#include <stdlib.h>
+#include <pthread.h>
+
+#include "TUM_Font.h"
+#include "TUM_Utils.h"
+
+#define PRINT_TTF_ERROR(msg, ...)                                              \
+	PRINT_ERROR("[TTF Error] %s\n" #msg, (char *)TTF_GetError(),           \
+		    ##__VA_ARGS__)
+
+struct tum_font_ref {
+	TTF_Font *font;
+	unsigned ref_count;
+	unsigned pending_free;
+};
+
+typedef struct tum_font {
+	char *path;
+	char *name;
+	struct tum_font_ref font;
+	unsigned size;
+	struct tum_font *next;
+} tum_font_t;
+
+pthread_mutex_t list_lock = PTHREAD_MUTEX_INITIALIZER;
+static struct tum_font font_list = { 0 };
+
+static const char *fonts_dir;
+static struct tum_font *cur_default_font = NULL;
+
+static char *getFontPath(char *font_name)
+{
+	unsigned font_dir_len = strlen(fonts_dir);
+	unsigned font_len = strnlen(font_name, MAX_FONT_NAME_LENGTH);
+
+	if ((font_dir_len + strlen(font_name)) > MAX_FONT_NAME_LENGTH)
+		return NULL;
+
+	char *ret = (char *)calloc(font_dir_len + font_len + 1, sizeof(char));
+	if (ret == NULL)
+		return NULL;
+
+	strcpy(ret, fonts_dir);
+	strcpy(ret + font_dir_len, font_name);
+
+	return ret;
+}
+
+static struct tum_font *tumFontCreateFont(char *font_name, ssize_t size)
+{
+	struct tum_font *ret;
+
+	ret = calloc(1, sizeof(struct tum_font));
+	if (ret == NULL)
+		goto err_alloc_def_font;
+
+	ret->path = getFontPath(font_name);
+	if (ret->path == NULL)
+		goto err_get_font_path;
+
+	ret->name = ret->path + strlen(fonts_dir);
+	ret->size = size;
+
+	ret->font.font = TTF_OpenFont(ret->path, ret->size);
+	if (ret->font.font == NULL) {
+		PRINT_TTF_ERROR("Failed to load default font");
+		goto err_font_open;
+	}
+
+	ret->font.ref_count = 0;
+	ret->font.pending_free = 0;
+
+	return ret;
+
+err_font_open:
+	free(ret->path);
+err_get_font_path:
+	free(ret);
+err_alloc_def_font:
+	return NULL;
+}
+
+int tumFontInit(char *path)
+{
+	fonts_dir = prepend_path(path, FONTS_DIRECTORY);
+
+	font_list.next = tumFontCreateFont(DEFAULT_FONT, DEFAULT_FONT_SIZE);
+	if (font_list.next == NULL)
+		return -1;
+
+	cur_default_font = font_list.next;
+
+	return 0;
+}
+
+void tumFontDeleteFont(struct tum_font *font)
+{
+	free(font->path);
+	TTF_CloseFont(font->font.font);
+	free(font);
+	font = NULL;
+}
+
+void tumFontExit(void)
+{
+	pthread_mutex_lock(&list_lock);
+	struct tum_font *iterator = font_list.next;
+	struct tum_font *delete = NULL;
+
+	while (iterator) {
+		delete = iterator;
+		iterator = iterator->next;
+
+		tumFontDeleteFont(delete);
+	}
+
+	pthread_mutex_unlock(&list_lock);
+}
+
+void tumFontPutFontHandle(font_handle_t font)
+{
+	pthread_mutex_lock(&list_lock);
+	struct tum_font *iterator = &font_list;
+	struct tum_font *delete = NULL;
+
+	for (; iterator; iterator = iterator->next) {
+		if (iterator == font) {
+			iterator->font.ref_count--;
+			if (iterator->font.ref_count == 0 &&
+			    iterator->font.pending_free) {
+				if (iterator->next) {
+					if (delete)
+						delete->next = iterator->next;
+					else
+						font_list.next = iterator->next;
+				}
+				tumFontDeleteFont(iterator);
+			}
+			pthread_mutex_unlock(&list_lock);
+			return;
+		}
+		delete = iterator;
+	}
+	pthread_mutex_unlock(&list_lock);
+
+}
+
+void tumFontPutFont(TTF_Font *font)
+{
+	pthread_mutex_lock(&list_lock);
+	struct tum_font *iterator = &font_list;
+	struct tum_font *delete = NULL;
+
+	for (; iterator; iterator = iterator->next) {
+		if (iterator->font.font == font) {
+			iterator->font.ref_count--;
+			if (iterator->font.ref_count == 0 &&
+			    iterator->font.pending_free) {
+				if (iterator->next) {
+					if (delete)
+						delete->next = iterator->next;
+					else
+						font_list.next = iterator->next;
+				}
+				tumFontDeleteFont(iterator);
+			}
+			pthread_mutex_unlock(&list_lock);
+			return;
+		}
+		delete = iterator;
+	}
+	pthread_mutex_unlock(&list_lock);
+}
+
+TTF_Font *tumFontGetCurFont(void)
+{
+	TTF_Font *ret;
+
+	pthread_mutex_lock(&list_lock);
+
+	cur_default_font->font.ref_count++;
+	ret = cur_default_font->font.font;
+
+	pthread_mutex_unlock(&list_lock);
+
+	return ret;
+}
+
+ssize_t tumFontGetCurFontSize(void)
+{
+	pthread_mutex_lock(&list_lock);
+	ssize_t ret = cur_default_font->size;
+	pthread_mutex_unlock(&list_lock);
+	return ret;
+}
+
+char *tumFontGetCurFontName(void)
+{
+	pthread_mutex_lock(&list_lock);
+	char *ret = strdup(cur_default_font->name);
+	pthread_mutex_unlock(&list_lock);
+	return ret;
+}
+
+font_handle_t tumFontGetCurFontHandle(void)
+{
+	pthread_mutex_lock(&list_lock);
+	cur_default_font->font.ref_count++;
+	font_handle_t ret = cur_default_font;
+	pthread_mutex_unlock(&list_lock);
+	return ret;
+}
+
+static struct tum_font *tumFontAppendFont(char *font_name, ssize_t size)
+{
+	struct tum_font *iterator = &font_list;
+
+	for (; iterator->next; iterator = iterator->next)
+		;
+
+	iterator->next = tumFontCreateFont(font_name, size);
+	if (iterator->next == NULL) {
+		return NULL;
+	}
+
+	return iterator->next;
+}
+
+int tumFontLoadFont(char *font_name, ssize_t size)
+{
+	int ret = 0;
+
+	pthread_mutex_lock(&list_lock);
+
+	if (tumFontAppendFont(font_name, (size) ? size : DEFAULT_FONT_SIZE) ==
+	    NULL)
+		ret = -1;
+
+	pthread_mutex_unlock(&list_lock);
+
+	return ret;
+}
+
+int tumFontSelectFontFromName(char *font_name)
+{
+	pthread_mutex_lock(&list_lock);
+	struct tum_font *iterator = &font_list;
+
+	for (; iterator; iterator = iterator->next)
+		if (iterator->name)
+			if (!strcmp(iterator->name, font_name)) {
+				cur_default_font = iterator;
+				pthread_mutex_unlock(&list_lock);
+				return 0;
+			}
+
+	pthread_mutex_unlock(&list_lock);
+
+	return -1;
+}
+
+int tumFontSelectFontFromHandle(font_handle_t font_handle)
+{
+	pthread_mutex_lock(&list_lock);
+	struct tum_font *iterator = &font_list;
+
+	for (; iterator; iterator = iterator->next)
+		if (iterator == font_handle) {
+			cur_default_font = iterator;
+			pthread_mutex_unlock(&list_lock);
+			return 0;
+		}
+
+	pthread_mutex_unlock(&list_lock);
+
+	return -1;
+}
+
+int tumFontSetSize(ssize_t font_size)
+{
+	if (cur_default_font == NULL)
+		goto err_;
+
+	pthread_mutex_lock(&list_lock);
+
+	if (cur_default_font->size == font_size) {
+		pthread_mutex_unlock(&list_lock);
+		return 0;
+	}
+
+	if (!cur_default_font->font.ref_count) {
+		TTF_CloseFont(cur_default_font->font.font);
+		TTF_Font *new_font =
+			TTF_OpenFont(cur_default_font->path, font_size);
+
+		if (new_font == NULL)
+			goto err_;
+
+		cur_default_font->font.font = new_font;
+		cur_default_font->size = font_size;
+	} else {
+		cur_default_font->font.pending_free = 1;
+		cur_default_font =
+			tumFontAppendFont(cur_default_font->name, font_size);
+		if (!cur_default_font)
+			goto err_;
+	}
+
+	pthread_mutex_unlock(&list_lock);
+
+	return 0;
+err_:
+	pthread_mutex_unlock(&list_lock);
+	return -1;
+}

--- a/lib/Gfx/include/TUM_Draw.h
+++ b/lib/Gfx/include/TUM_Draw.h
@@ -43,21 +43,6 @@
 #define WINDOW_TITLE "FreeRTOS Emulator"
 
 /**
- * Defines the default font size used by the SDL TTF library
- */
-#define DEFAULT_FONT_SIZE 15
-
-/**
- * Default font to be used by the SDL TTF library
- */
-#define DEFAULT_FONT "IBMPlexSans-Medium.ttf"
-/**
- * Location of font TTF files
- */
-#define FONTS_LOCATION "/../resources/fonts/"
-#define FONT_LOCATION FONTS_LOCATION DEFAULT_FONT
-
-/**
  * Sets the width (in pixels) of the screen
  */
 #define SCREEN_WIDTH 640

--- a/lib/Gfx/include/TUM_Font.h
+++ b/lib/Gfx/include/TUM_Font.h
@@ -1,0 +1,174 @@
+
+/**
+ * @file TUM_Font.h
+ * @author Alex Hoffman
+ * @date 30 April 2020
+ * @brief Manages fonts used in TUM Draw
+ *
+ * @verbatim
+ ----------------------------------------------------------------------
+ Copyright (C) Alexander Hoffman, 2020
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ----------------------------------------------------------------------
+ @endverbatim
+ */
+
+#ifndef __TUM_FONT_H__
+#define __TUM_FONT_H__
+
+#include <SDL2/SDL_ttf.h>
+
+/**
+ * Defines the default font size used by the SDL TTF library
+ */
+#define DEFAULT_FONT_SIZE 15
+
+/**
+ * Default font to be used by the SDL TTF library
+ */
+#define DEFAULT_FONT "IBMPlexSans-Medium.ttf"
+
+/**
+ * Location of font TTF files
+ */
+#ifndef FONTS_DIRECTORY
+#define FONTS_DIRECTORY "/../resources/fonts/"
+#endif // FONTS_DIRECTORY
+
+/**
+ * Maximum length of allowed font file names, helps to prevent memory overflows
+ */
+#define MAX_FONT_NAME_LENGTH 256
+
+/**
+ * @brief Handle used to reference a specific font/size configuration when
+ * restoring a font using tumFontSelectFontFromHandle(), current font can be
+ * retrieved using tumFontGetCurFontHandle().
+ */
+typedef void *font_handle_t;
+
+/**
+ * @brief Loads a font with the given font name from the FONTS_DIRECTORY
+ * directory, by default this is in `resources/fonts`
+ *
+ * @param font_name A string representation of the fonts filename, including
+ * suffix (.ttf)
+ * @param size The size that the font should have, if 0 is passed then the
+ * default font size will be used, defined by DEFAULT_FONT_SIZE
+ * @return 0 on success
+ */
+int tumFontLoadFont(char *font_name, ssize_t size);
+
+/**
+ * @brief Initializes the font backend, the executing binary path is required,
+ * this is usually already passed to TUM_Draw init and subsequently to
+ * tumFontInit
+ *
+ * @param path Executing binary's directory path
+ * @return 0 on success
+ */
+int tumFontInit(char *path);
+
+/**
+ * @brief Exits the font backend
+ *
+ */
+void tumFontExit(void);
+
+/**
+ * @brief Retrieved a reference to the current SDL2 TTF font, increasing the
+ * reference count of the respective tum_font object. Objects can not be
+ * free'd until all references have been put, this for each call to
+ * tumFontGetCurFont() a call to tumFontPutFont() must be made, passing in the
+ * SDL2 TTF font reference returned from this function.
+ *
+ * @return A reference to the SDL2 TTF font currently loaded as the font
+ * backend's active font
+ */
+TTF_Font *tumFontGetCurFont(void);
+
+/**
+ * @brief Finds the tum_font object associated with the loaded SDL2 TFF font,
+ * decreasing the reference count to the object with each call, once an object's
+ * reference count has reached zero and the font backed has flagged the tum_font
+ * object as no longer being needed it is then free'd.
+ *
+ * @param font SDL2 TTF font reference, retrieved originally via tumFontGetCurFont()
+ */
+void tumFontPutFont(TTF_Font *font);
+
+/**
+ * @brief Finds the tum_font object associated with the loaded SDL2 TFF font,
+ * decreasing the reference count to the object with each call, once an object's
+ * reference count has reached zero and the font backed has flagged the tum_font
+ * object as no longer being needed it is then free'd.
+ *
+ * @param font Font handle, retrieved originally via tumFontGetCurFontHandle()
+ */
+void tumFontPutFontHandle(font_handle_t font);
+
+/**
+ * @brief Retrieved a handle to the current font, unlike tumFontGetCurFont()
+ * the handle contains the TUM_Font's metadata structure for the font instance
+ * where as tumFontGetCurFont() returns a SDL2 TTF Font reference.
+ *
+ * @return Handle to the currently active font
+ */
+font_handle_t tumFontGetCurFontHandle(void);
+
+/**
+ * @brief Returns the size of the currently active font
+ *
+ * @return The size of the currently active font
+ */
+ssize_t tumFontGetCurFontSize(void);
+
+/**
+ * @brief Retrieved the string name of the currently active font
+ *
+ * @return A string copy of the currently active font, allocated using malloc,
+ * must be free'd
+ */
+char *tumFontGetCurFontName(void);
+
+/**
+ * @brief Sets the active font from a string of the font's filename. The filename
+ * is not the absolute file but the font's name within the FONT_DIRECTORY
+ * directory. The font is only able to be made active if it was firstly loaded
+ * using tumFontLoadFont().
+ *
+ * @param font_name A string of the .ttf file to be loaded, including suffix
+ * @return 0 on success
+ */
+int tumFontSelectFontFromName(char *font_name);
+
+/**
+ * @brief Sets the active font based off of a font handle
+ *
+ * @param font_handle A handle retrieved originally using tumFontGetCurFontHandle()
+ * @return 0 on success
+ */
+int tumFontSelectFontFromHandle(font_handle_t font_handle);
+
+/**
+ * @brief Sets the size of the current font to be used. The font is set by making
+ * a copy of the current font if the current font's configuration (font + size)
+ * is being referenced by pending draw jobs. All subsequent text draw jobs
+ * will use the currently active font and the specified size until the size
+ * and/or font are changed again.
+ *
+ * @param font_size New size that the currently active font should take
+ * @return 0 on success
+ */
+int tumFontSetSize(ssize_t font_size);
+
+#endif // __TUM_FONT_H__

--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 
 #include "TUM_Ball.h"
 #include "TUM_Draw.h"
+#include "TUM_Font.h"
 #include "TUM_Event.h"
 #include "TUM_Sound.h"
 #include "TUM_Utils.h"
@@ -239,6 +240,9 @@ void vDrawHelpText(void)
 {
     static char str[100] = { 0 };
     static int text_width;
+    ssize_t prev_font_size = tumFontGetCurFontSize();
+
+    tumFontSetSize((ssize_t)30);
 
     sprintf(str, "[Q]uit, [C]hange State");
 
@@ -246,9 +250,12 @@ void vDrawHelpText(void)
         checkDraw(tumDrawText(str, SCREEN_WIDTH - text_width - 10,
                               DEFAULT_FONT_SIZE * 0.5, Black),
                   __FUNCTION__);
+
+    tumFontSetSize(prev_font_size);
 }
 
 #define FPS_AVERAGE_COUNT 50
+#define FPS_FONT "IBMPlexSans-Bold.ttf"
 
 void vDrawFPS(void)
 {
@@ -260,6 +267,7 @@ void vDrawFPS(void)
     static char str[10] = { 0 };
     static int text_width;
     int fps = 0;
+    font_handle_t cur_font = tumFontGetCurFontHandle();
 
     xLastWakeTime = xTaskGetTickCount();
 
@@ -290,6 +298,8 @@ void vDrawFPS(void)
 
     fps = periods_total / average_count;
 
+    tumFontSelectFontFromName(FPS_FONT);
+
     sprintf(str, "FPS: %2d", fps);
 
     if (!tumGetTextSize((char *)str, &text_width, NULL))
@@ -297,6 +307,9 @@ void vDrawFPS(void)
                               SCREEN_HEIGHT - DEFAULT_FONT_SIZE * 1.5,
                               Skyblue),
                   __FUNCTION__);
+
+    tumFontSelectFontFromHandle(cur_font);
+    tumFontPutFontHandle(cur_font);
 }
 
 void vDrawLogo(void)
@@ -640,6 +653,9 @@ int main(int argc, char *argv[])
     }
 
     atexit(aIODeinit);
+
+    //Load a second font for fun
+    tumFontLoadFont(FPS_FONT, DEFAULT_FONT_SIZE);
 
     buttons.lock = xSemaphoreCreateMutex(); // Locking mechanism
     if (!buttons.lock) {


### PR DESCRIPTION
… draw jobs using existing font instances

I added in TUM_Font which stores a linked list of referenced TTF_Font instances that are then tracked and created/destroyed depending on calls to things such as `tumFontSetSize`. Mainly just implemented changing font size for now. Will look at loading multiple fonts and and drawing with multiple fonts in my next commit. Was an interesting little exercise. Also need to add documentation.