### PR TITLE
Bugfix: FPS averaging was slightly wrong

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -279,6 +279,13 @@ void vDrawFPS(void)
     int fps = 0;
     font_handle_t cur_font = tumFontGetCurFontHandle();
 
+    if (average_count < FPS_AVERAGE_COUNT) {
+        average_count++;
+    }
+    else {
+        periods_total -= periods[index];
+    }
+
     xLastWakeTime = xTaskGetTickCount();
 
     if (prevWakeTime != xLastWakeTime) {
@@ -297,13 +304,6 @@ void vDrawFPS(void)
     }
     else {
         index++;
-    }
-
-    if (average_count < FPS_AVERAGE_COUNT) {
-        average_count++;
-    }
-    else {
-        periods_total -= periods[index];
     }
 
     fps = periods_total / average_count;


### PR DESCRIPTION
I stumbled across this as I wrote a short code snipped inspired by the frame rate averaging in the Emulator. 

I my opinion the old element has to be removed from the array before the new period is added. Else the value which is subtracted from the total sum is the one index off. This can result in framerates > 50.