### PR TITLE
Stop cmake from rebuilding astyle on every 'make'

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -63,6 +63,7 @@ if(ENABLE_ASTYLE)
         DOWNLOAD_DIR        ${CMAKE_BINARY_DIR}/external/astyle/download
         SOURCE_DIR          ${CMAKE_BINARY_DIR}/external/astyle/src
         BINARY_DIR          ${CMAKE_BINARY_DIR}/external/astyle/build
+        UPDATE_COMMAND      "" # this keeps cmake from rebuilding astyle every time you run "make"
     )
 
     list(APPEND ASTYLE_ARGS


### PR DESCRIPTION
Currently, every time you run 'make' with 'ENABLE_ASTYLE=ON', astyle is updated and built. Setting the update command to `""` stops this behavior. 

I'd argue this is a sensible default.